### PR TITLE
Feat/add footer tabs

### DIFF
--- a/config/Migrations/20250906150252_AddFooterSettings.php
+++ b/config/Migrations/20250906150252_AddFooterSettings.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+use Cake\Utility\Text;
+
+class AddFooterSettings extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     * @return void
+     */
+    public function change(): void
+    {
+        // Add footer_menu field to articles table
+        $table = $this->table('articles');
+        $table->addColumn('footer_menu', 'boolean', [
+            'default' => false,
+            'null' => false,
+            'after' => 'main_menu'
+        ]);
+        $table->update();
+        
+        // Insert footer settings
+        $this->table('settings')
+            ->insert([
+                'id' => Text::uuid(),
+                'ordering' => 4,
+                'category' => 'SitePages',
+                'key_name' => 'footerMenuShow',
+                'value' => 'selected',
+                'value_type' => 'select',
+                'value_obscure' => false,
+                'description' => 'Should the footer menu show all root pages or only selected pages?',
+                'data' => json_encode([
+                    'root' => 'Top Level Pages',
+                    'selected' => 'Selected Pages'
+                ]),
+                'column_width' => 2
+            ])
+            ->save();
+    }
+}

--- a/plugins/AdminTheme/templates/Admin/Articles/tree_index.php
+++ b/plugins/AdminTheme/templates/Admin/Articles/tree_index.php
@@ -1,5 +1,6 @@
 <?php
 $activeFilter = $this->request->getQuery('status');
+$menuFilter = $this->request->getQuery('menu');
 if ($activeFilter === null) {
     $this->Html->script('https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js', ['block' => true]);
     $this->Html->script('articles_tree', ['block' => true]);
@@ -41,6 +42,56 @@ if ($activeFilter === null) {
               </li>
             </ul>
           </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" aria-expanded="false"><?= __('Menu') ?></a>
+            <ul class="dropdown-menu">
+              <li>
+                <?= $this->Html->link(
+                    __('All'), 
+                    ['action' => 'treeIndex', 'id' => '', '?' => array_filter(['status' => $activeFilter])], 
+                    [
+                      'class' => 'dropdown-item' . ($menuFilter === null ? ' active' : '')
+                    ]
+                ) ?>
+              </li>
+              <li>
+                <?= $this->Html->link(
+                    __('Header Menu'), 
+                    ['action' => 'treeIndex', 'id' => '', '?' => array_filter(['status' => $activeFilter, 'menu' => 'header'])], 
+                    [
+                      'class' => 'dropdown-item' . ($menuFilter === 'header' ? ' active' : '')
+                    ]
+                ) ?>
+              </li>
+              <li>
+                <?= $this->Html->link(
+                    __('Footer Menu'), 
+                    ['action' => 'treeIndex', 'id' => '', '?' => array_filter(['status' => $activeFilter, 'menu' => 'footer'])], 
+                    [
+                      'class' => 'dropdown-item' . ($menuFilter === 'footer' ? ' active' : '')
+                    ]
+                ) ?>
+              </li>
+              <li>
+                <?= $this->Html->link(
+                    __('Both Menus'), 
+                    ['action' => 'treeIndex', 'id' => '', '?' => array_filter(['status' => $activeFilter, 'menu' => 'both'])], 
+                    [
+                      'class' => 'dropdown-item' . ($menuFilter === 'both' ? ' active' : '')
+                    ]
+                ) ?>
+              </li>
+              <li>
+                <?= $this->Html->link(
+                    __('No Menu'), 
+                    ['action' => 'treeIndex', 'id' => '', '?' => array_filter(['status' => $activeFilter, 'menu' => 'none'])], 
+                    [
+                      'class' => 'dropdown-item' . ($menuFilter === 'none' ? ' active' : '')
+                    ]
+                ) ?>
+              </li>
+            </ul>
+          </li>
         </ul>
         <form class="d-flex-grow-1 me-3" role="search">
           <input id="pageSearch" type="search" class="form-control" placeholder="<?= __('Search Pages...') ?>" aria-label="Search">
@@ -73,9 +124,16 @@ document.addEventListener('DOMContentLoaded', function() {
         debounceTimer = setTimeout(() => {
             const searchTerm = this.value.trim();
             let url = `<?= $this->Url->build(['action' => 'treeIndex']) ?>`;
+            let params = [];
             <?php if (null !== $activeFilter): ?>
-            url += `?status=<?= urlencode($activeFilter) ?>`;
+            params.push('status=<?= urlencode($activeFilter) ?>');
             <?php endif; ?>
+            <?php if (null !== $menuFilter): ?>
+            params.push('menu=<?= urlencode($menuFilter) ?>');
+            <?php endif; ?>
+            if (params.length > 0) {
+                url += '?' + params.join('&');
+            }
             if (searchTerm.length > 0) {
                 url += (url.includes('?') ? '&' : '?') + `search=${encodeURIComponent(searchTerm)}`;
                 fetch(url, {

--- a/plugins/AdminTheme/templates/element/form/article.php
+++ b/plugins/AdminTheme/templates/element/form/article.php
@@ -155,6 +155,22 @@
     </div>
     <?php endif; ?>
 
+    <?php if ($kind == 'page' && SettingsManager::read('SitePages.footerMenuShow') == 'selected') : ?>
+    <div class="form-check">
+        <?php echo $this->Form->checkbox('footer_menu', [
+            'class' => 'form-check-input' . ($this->Form->isFieldError('footer_menu') ? ' is-invalid' : '')
+        ]); ?>
+        <label class="form-check-label" for="footer_menu">
+            <?= __('Footer Menu') ?>
+        </label>
+        <?php if ($this->Form->isFieldError('footer_menu')): ?>
+            <div class="invalid-feedback">
+                <?= $this->Form->error('footer_menu') ?>
+            </div>
+        <?php endif; ?>
+    </div>
+    <?php endif; ?>
+
 </div>
 <div class="mb-3">
     <?php $parentId = $this->request->getQuery('parent_id'); ?>

--- a/plugins/AdminTheme/templates/element/form/article.php
+++ b/plugins/AdminTheme/templates/element/form/article.php
@@ -140,35 +140,57 @@
     <?php endif; ?>
 
     <?php if ($kind == 'page' && SettingsManager::read('SitePages.mainMenuShow') == 'selected') : ?>
-    <div class="form-check">
-        <?php echo $this->Form->checkbox('main_menu', [
-            'class' => 'form-check-input' . ($this->Form->isFieldError('main_menu') ? ' is-invalid' : '')
-        ]); ?>
-        <label class="form-check-label" for="main_menu">
-            <?= __('Main Menu') ?>
-        </label>
-        <?php if ($this->Form->isFieldError('main_menu')): ?>
-            <div class="invalid-feedback">
-                <?= $this->Form->error('main_menu') ?>
-            </div>
-        <?php endif; ?>
-    </div>
+        <?php 
+        // Check if this is a child page and if it inherits from parent
+        $isChildPage = !empty($article->parent_id);
+        $inheritedFromParent = false;
+        if ($isChildPage && isset($parentInheritance)) {
+            $inheritedFromParent = $parentInheritance['main_menu'] ?? false;
+        }
+        ?>
+        <div class="form-check<?php if($inheritedFromParent): ?> inherited-setting<?php endif; ?>">
+            <?php echo $this->Form->checkbox('main_menu', [
+                'class' => 'form-check-input' . ($this->Form->isFieldError('main_menu') ? ' is-invalid' : '')
+            ]); ?>
+            <label class="form-check-label" for="main_menu">
+                <?= __('Main Menu') ?>
+                <?php if($inheritedFromParent): ?>
+                    <small class="text-muted d-block">⬆️ <?= __('Inherited from parent page') ?></small>
+                <?php endif; ?>
+            </label>
+            <?php if ($this->Form->isFieldError('main_menu')): ?>
+                <div class="invalid-feedback">
+                    <?= $this->Form->error('main_menu') ?>
+                </div>
+            <?php endif; ?>
+        </div>
     <?php endif; ?>
 
     <?php if ($kind == 'page' && SettingsManager::read('SitePages.footerMenuShow') == 'selected') : ?>
-    <div class="form-check">
-        <?php echo $this->Form->checkbox('footer_menu', [
-            'class' => 'form-check-input' . ($this->Form->isFieldError('footer_menu') ? ' is-invalid' : '')
-        ]); ?>
-        <label class="form-check-label" for="footer_menu">
-            <?= __('Footer Menu') ?>
-        </label>
-        <?php if ($this->Form->isFieldError('footer_menu')): ?>
-            <div class="invalid-feedback">
-                <?= $this->Form->error('footer_menu') ?>
-            </div>
-        <?php endif; ?>
-    </div>
+        <?php 
+        // Check if this is a child page and if it inherits from parent
+        $isChildPage = !empty($article->parent_id);
+        $inheritedFromParentFooter = false;
+        if ($isChildPage && isset($parentInheritance)) {
+            $inheritedFromParentFooter = $parentInheritance['footer_menu'] ?? false;
+        }
+        ?>
+        <div class="form-check<?php if($inheritedFromParentFooter): ?> inherited-setting<?php endif; ?>">
+            <?php echo $this->Form->checkbox('footer_menu', [
+                'class' => 'form-check-input' . ($this->Form->isFieldError('footer_menu') ? ' is-invalid' : '')
+            ]); ?>
+            <label class="form-check-label" for="footer_menu">
+                <?= __('Footer Menu') ?>
+                <?php if($inheritedFromParentFooter): ?>
+                    <small class="text-muted d-block">⬆️ <?= __('Inherited from parent page') ?></small>
+                <?php endif; ?>
+            </label>
+            <?php if ($this->Form->isFieldError('footer_menu')): ?>
+                <div class="invalid-feedback">
+                    <?= $this->Form->error('footer_menu') ?>
+                </div>
+            <?php endif; ?>
+        </div>
     <?php endif; ?>
 
 </div>

--- a/plugins/AdminTheme/templates/element/tree/page_tree.php
+++ b/plugins/AdminTheme/templates/element/tree/page_tree.php
@@ -23,6 +23,18 @@
                     <span class="badge me-3 <?= $article->is_published ? 'bg-success' : 'bg-secondary' ?>">
                         <?= $article->is_published ? 'Published' : 'Unpublished' ?>
                     </span>
+                    <?php
+                    // Display menu status badges
+                    if ($article->main_menu && $article->footer_menu) {
+                        echo '<span class="badge bg-primary me-2" title="Appears in both header and footer menus">Both Menus</span>';
+                    } elseif ($article->main_menu) {
+                        echo '<span class="badge bg-info me-2" title="Appears in header menu">Header Menu</span>';
+                    } elseif ($article->footer_menu) {
+                        echo '<span class="badge bg-warning me-2" title="Appears in footer menu">Footer Menu</span>';
+                    } else {
+                        echo '<span class="badge bg-light text-dark me-2" title="Not in any menu">No Menu</span>';
+                    }
+                    ?>
                     <?= $this->Html->link(
                         '<span class="badge bg-info me-3">' . __('{0} Views', $article->view_count) . '</span>',
                         [

--- a/plugins/DefaultTheme/src/Controller/Component/FrontEndSiteComponent.php
+++ b/plugins/DefaultTheme/src/Controller/Component/FrontEndSiteComponent.php
@@ -85,7 +85,7 @@ class FrontEndSiteComponent extends Component
                 $menuPages = $articlesTable->getRootPages($cacheKey);
                 break;
             case "selected":
-                $menuPages = $articlesTable->getMainMenuPages($cacheKey);
+                $menuPages = $articlesTable->getMainMenuPagesWithChildren($cacheKey);
                 break;
         }
 
@@ -126,7 +126,7 @@ class FrontEndSiteComponent extends Component
                 $footerMenuPages = $articlesTable->getRootPages($cacheKey);
                 break;
             case "selected":
-                $footerMenuPages = $articlesTable->getFooterMenuPages($cacheKey);
+                $footerMenuPages = $articlesTable->getFooterMenuPagesWithChildren($cacheKey);
                 break;
         }
         

--- a/plugins/DefaultTheme/src/Controller/Component/FrontEndSiteComponent.php
+++ b/plugins/DefaultTheme/src/Controller/Component/FrontEndSiteComponent.php
@@ -119,6 +119,17 @@ class FrontEndSiteComponent extends Component
             }
         }
         
+        // Get footer menu pages based on settings
+        $footerMenuPages = [];
+        switch(SettingsManager::read('SitePages.footerMenuShow', 'selected')) {
+            case "root":
+                $footerMenuPages = $articlesTable->getRootPages($cacheKey);
+                break;
+            case "selected":
+                $footerMenuPages = $articlesTable->getFooterMenuPages($cacheKey);
+                break;
+        }
+        
 
         //////////////////////////////////// SET  functions for the templates, accessible in the views without the need to pass them explicitly to the controller ////////////////////
         // Set the view variables for the front-end site
@@ -126,6 +137,7 @@ class FrontEndSiteComponent extends Component
         // and can be used to render the menu, tags, featured articles, and archives.
         $controller->set(compact(
             'menuPages',
+            'footerMenuPages',
             'rootTags',
             'featuredArticles',
             'articleArchives',

--- a/plugins/DefaultTheme/templates/element/site/footer.php
+++ b/plugins/DefaultTheme/templates/element/site/footer.php
@@ -1,18 +1,84 @@
 <?php use App\Utility\SettingsManager; ?>
 <footer class="py-5 text-center text-body-secondary bg-body-tertiary">
-    <p>&copy; <?= date('Y') ?> <?= SettingsManager::read('SEO.siteName', 'Willow CMS') ?>. <?= __(singular: 'All rights reserved.') ?></p>
-    <?php if (!empty($sitePrivacyPolicy)) : ?>
-    <p class="mb-0">
-        <?= $this->Html->link(
-            __('Privacy Policy'),
-            [
-                '_name' => 'page-by-slug',
-                'slug' => $sitePrivacyPolicy['slug']
-            ]
-        ); ?>
-    </p>
-    <?php endif; ?>
-    <p class="mb-0">
-        <a href="#"><?= __('Back to top') ?></a>
-    </p>
+    <div class="container">
+        <!-- Footer Menu Pages -->
+        <?php if (!empty($footerMenuPages)) : ?>
+        <div class="row justify-content-center mb-4">
+            <div class="col-md-8">
+                <h6 class="text-uppercase fw-bold mb-3 text-primary"><?= __('Footer Pages') ?></h6>
+                <div class="footer-menu-pages">
+                    <nav class="nav justify-content-center flex-wrap">
+                        <?php foreach ($footerMenuPages as $footerPage): ?>
+                        <div class="nav-item mx-2 mb-2">
+                            <?= $this->Html->link(
+                                h($footerPage->title),
+                                [
+                                    '_name' => 'page-by-slug',
+                                    'slug' => $footerPage->slug
+                                ],
+                                [
+                                    'class' => 'nav-link text-body-secondary footer-page-link px-2 py-1 rounded',
+                                    'style' => 'border: 1px solid rgba(var(--bs-secondary-rgb), 0.3); background: rgba(var(--bs-light-rgb), 0.1);'
+                                ]
+                            ); ?>
+                        </div>
+                        <?php endforeach; ?>
+                    </nav>
+                </div>
+                <hr class="my-4 opacity-50">
+            </div>
+        </div>
+        <?php endif; ?>
+        
+        <!-- Copyright and Standard Footer Links -->
+        <p class="mb-3">&copy; <?= date('Y') ?> <?= SettingsManager::read('SEO.siteName', 'Willow CMS') ?>. <?= __(singular: 'All rights reserved.') ?></p>
+        
+        <!-- Standard Footer Links -->
+        <div class="footer-standard-links mb-3">
+            <?php if (!empty($sitePrivacyPolicy)) : ?>
+                <?= $this->Html->link(
+                    __('Privacy Policy'),
+                    [
+                        '_name' => 'page-by-slug',
+                        'slug' => $sitePrivacyPolicy['slug']
+                    ],
+                    [
+                        'class' => 'text-body-secondary text-decoration-none me-3'
+                    ]
+                ); ?>
+            <?php endif; ?>
+            <a href="#" class="text-body-secondary text-decoration-none"><?= __('Back to top') ?></a>
+        </div>
+    </div>
 </footer>
+
+<style>
+.footer-page-link {
+    transition: all 0.2s ease;
+    font-size: 0.9rem;
+    font-weight: 500;
+}
+
+.footer-page-link:hover {
+    background: rgba(var(--bs-primary-rgb), 0.1) !important;
+    border-color: var(--bs-primary) !important;
+    transform: translateY(-1px);
+    color: var(--bs-primary) !important;
+}
+
+.footer-menu-pages {
+    margin-bottom: 1rem;
+}
+
+.footer-menu-pages h6 {
+    font-size: 0.8rem;
+    letter-spacing: 0.1em;
+}
+
+@media (max-width: 768px) {
+    .footer-page-link {
+        font-size: 0.85rem;
+        margin: 0.25rem;
+    }
+}
+</style>

--- a/src/Controller/Admin/ArticlesController.php
+++ b/src/Controller/Admin/ArticlesController.php
@@ -252,10 +252,26 @@ class ArticlesController extends AppController
                 ->all();
         }
 
+        // Get parent inheritance data for menu settings (in case parent_id is set in query params)
+        $parentInheritance = [];
+        $parentId = $this->request->getQuery('parent_id');
+        if (!empty($parentId)) {
+            try {
+                $parent = $this->Articles->get($parentId);
+                $parentInheritance = [
+                    'main_menu' => $parent->main_menu ?? false,
+                    'footer_menu' => $parent->footer_menu ?? false,
+                    'parent_title' => $parent->title ?? ''
+                ];
+            } catch (RecordNotFoundException $e) {
+                // Parent not found, continue without inheritance data
+            }
+        }
+
         $users = $this->Articles->Users->find('list', limit: 200)->all();
         $tags = $this->Articles->Tags->find('list', limit: 200)->all();
         $token = $this->request->getAttribute('csrfToken');
-        $this->set(compact('article', 'users', 'tags', 'token', 'parentArticles'));
+        $this->set(compact('article', 'users', 'tags', 'token', 'parentArticles', 'parentInheritance'));
 
         return null;
     }
@@ -321,9 +337,20 @@ class ArticlesController extends AppController
                 ->all();
         }
 
+        // Get parent inheritance data for menu settings
+        $parentInheritance = [];
+        if (!empty($article->parent_id)) {
+            $parent = $this->Articles->get($article->parent_id);
+            $parentInheritance = [
+                'main_menu' => $parent->main_menu ?? false,
+                'footer_menu' => $parent->footer_menu ?? false,
+                'parent_title' => $parent->title ?? ''
+            ];
+        }
+
         $users = $this->Articles->Users->find('list', limit: 200)->all();
         $tags = $this->Articles->Tags->find('list', limit: 200)->all();
-        $this->set(compact('article', 'users', 'tags', 'parentArticles'));
+        $this->set(compact('article', 'users', 'tags', 'parentArticles', 'parentInheritance'));
 
         return null;
     }

--- a/src/Controller/Admin/ArticlesController.php
+++ b/src/Controller/Admin/ArticlesController.php
@@ -36,6 +36,7 @@ class ArticlesController extends AppController
     public function treeIndex(): ?Response
     {
         $statusFilter = $this->request->getQuery('status');
+        $menuFilter = $this->request->getQuery('menu');
         $conditions = [
             'Articles.kind' => 'page',
         ];
@@ -44,6 +45,19 @@ class ArticlesController extends AppController
             $conditions['Articles.is_published'] = '1';
         } elseif ($statusFilter === '0') {
             $conditions['Articles.is_published'] = '0';
+        }
+
+        // Apply menu filter
+        if ($menuFilter === 'header') {
+            $conditions['Articles.main_menu'] = 1;
+        } elseif ($menuFilter === 'footer') {
+            $conditions['Articles.footer_menu'] = 1;
+        } elseif ($menuFilter === 'both') {
+            $conditions['Articles.main_menu'] = 1;
+            $conditions['Articles.footer_menu'] = 1;
+        } elseif ($menuFilter === 'none') {
+            $conditions['Articles.main_menu'] = 0;
+            $conditions['Articles.footer_menu'] = 0;
         }
 
         if ($this->request->is('ajax')) {
@@ -63,6 +77,8 @@ class ArticlesController extends AppController
                 'created',
                 'modified',
                 'is_published',
+                'main_menu',
+                'footer_menu',
             ]);
 
             $this->set(compact('articles'));
@@ -77,6 +93,8 @@ class ArticlesController extends AppController
             'modified',
             'view_count',
             'is_published',
+            'main_menu',
+            'footer_menu',
         ]);
         $this->set(compact('articles'));
 

--- a/src/Model/Entity/Article.php
+++ b/src/Model/Entity/Article.php
@@ -15,6 +15,7 @@ use Cake\ORM\Entity;
  * @property string|null $lede
  * @property bool|null $featured
  * @property bool|null $main_menu
+ * @property bool|null $footer_menu
  * @property string|null $body
  * @property string|null $markdown
  * @property string|null $summary
@@ -62,6 +63,7 @@ class Article extends Entity
         'lede' => true,
         'featured' => true,
         'main_menu' => true,
+        'footer_menu' => true,
         'slug' => true,
         'body' => true,
         'markdown' => true,

--- a/src/Model/Table/ArticlesTable.php
+++ b/src/Model/Table/ArticlesTable.php
@@ -354,6 +354,39 @@ class ArticlesTable extends Table
     }
 
     /**
+     * Retrieves published pages marked for display in the footer menu.
+     *
+     * This method fetches articles that meet the following criteria:
+     * - Are of type 'page'
+     * - Are published (is_published = 1)
+     * - Are marked for footer menu display (footer_menu = 1)
+     * Results are ordered by the 'lft' field for proper tree structure display.
+     * Results are cached using the 'footer_menu_pages' key in the 'content' cache config.
+     *
+     * @param array $additionalConditions Additional conditions to merge with the default query conditions
+     * @return array List of Article entities matching the criteria
+     * @throws \Cake\Database\Exception\DatabaseException When the database query fails
+     * @throws \Cake\Cache\Exception\InvalidArgumentException When cache configuration is invalid
+     */
+    public function getFooterMenuPages(string $cacheKey, array $additionalConditions = []): array
+    {
+        $conditions = [
+            'Articles.kind' => 'page',
+            'Articles.is_published' => 1,
+            'Articles.footer_menu' => 1,
+        ];
+        $conditions = array_merge($conditions, $additionalConditions);
+        $query = $this->find()
+            ->where($conditions)
+            ->orderBy(['lft' => 'ASC'])
+            ->cache($cacheKey . 'footer_menu_pages', 'content');
+
+        $results = $query->all()->toList();
+
+        return $results;
+    }
+
+    /**
      * Gets an array of years and months that have published articles.
      *
      * This method queries the articles table to find all unique year/month combinations

--- a/webroot/admin_theme/css/enhanced-forms.css
+++ b/webroot/admin_theme/css/enhanced-forms.css
@@ -321,6 +321,45 @@ textarea.form-control {
     border-radius: 6px;
 }
 
+/* Inherited settings styling */
+.form-check.inherited-setting {
+    background: linear-gradient(135deg, var(--admin-info-bg) 0%, rgba(var(--admin-info-bg), 0.3) 100%);
+    border-left: 4px solid var(--admin-primary-bg);
+    position: relative;
+}
+
+.form-check.inherited-setting::before {
+    content: '👨‍👩‍👧‍👦';
+    position: absolute;
+    left: -0.5rem;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 1.2em;
+    opacity: 0.7;
+}
+
+.form-check.inherited-setting .form-check-label {
+    font-style: italic;
+    position: relative;
+}
+
+.form-check.inherited-setting .form-check-label small {
+    font-weight: 400;
+    font-size: 0.75rem;
+    color: var(--admin-info-text) !important;
+    background: rgba(var(--admin-primary-bg), 0.1);
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    border: 1px solid rgba(var(--admin-primary-bg), 0.2);
+    margin-top: 0.25rem;
+    display: inline-block;
+}
+
+.form-check.inherited-setting:hover {
+    background: linear-gradient(135deg, var(--admin-info-bg) 0%, rgba(var(--admin-info-bg), 0.5) 100%);
+    border-left-color: var(--admin-primary-hover-bg);
+}
+
 /* Enhanced actions card styling */
 .page-actions-floating {
     position: sticky;


### PR DESCRIPTION
This pull request introduces a comprehensive "Footer Menu" feature for site pages, allowing administrators to control which pages appear in the site's footer navigation. It includes database migrations, admin UI enhancements, backend logic for filtering and inheritance, and frontend rendering of footer menu pages. The changes also improve menu management by supporting both header and footer menus, menu status filtering, and inheritance of menu settings from parent pages.

**Key changes:**

**Database and Settings:**
- Added a new `footer_menu` boolean field to the `articles` table and a corresponding setting (`footerMenuShow`) to control footer menu display options.
- Updated the `Article` entity to include the new `footer_menu` property and made it mass-assignable. [[1]](diffhunk://#diff-ad9c44f29ce639dfad18070e861fa33c355a744b008a50cfe560cb924c3ee9d7R18) [[2]](diffhunk://#diff-ad9c44f29ce639dfad18070e861fa33c355a744b008a50cfe560cb924c3ee9d7R66)

**Admin UI and Filtering:**
- Enhanced the articles tree view to include a menu filter dropdown, allowing filtering by header, footer, both, or no menu assignment. [[1]](diffhunk://#diff-e670e110db55e4c5f1b2f9d64eef5b38c5777daaa093bba178c5857dfdb0c816R3) [[2]](diffhunk://#diff-e670e110db55e4c5f1b2f9d64eef5b38c5777daaa093bba178c5857dfdb0c816R45-R94) [[3]](diffhunk://#diff-fcf16543627b2b89223149a19e46321e3b0483f11a5557fb1880690bdabcec40R39) [[4]](diffhunk://#diff-fcf16543627b2b89223149a19e46321e3b0483f11a5557fb1880690bdabcec40R50-R62)
- Displayed badges in the admin page tree to indicate menu status (header, footer, both, or none) for each article.
- Updated the article form to support editing the `footer_menu` field, including inheritance from parent pages and visual cues for inherited settings. [[1]](diffhunk://#diff-90f7ae8e41f9c991bd321a13a8143c5b32107d15c1c972f95200a93d8b26061eL143-R159) [[2]](diffhunk://#diff-90f7ae8e41f9c991bd321a13a8143c5b32107d15c1c972f95200a93d8b26061eR169-R195)
- Passed parent menu inheritance data to the add and edit actions for use in the form. [[1]](diffhunk://#diff-fcf16543627b2b89223149a19e46321e3b0483f11a5557fb1880690bdabcec40R273-R292) [[2]](diffhunk://#diff-fcf16543627b2b89223149a19e46321e3b0483f11a5557fb1880690bdabcec40R358-R371)

**Backend Logic:**
- Added logic in the controller to filter articles by menu status in the admin tree view and to include `footer_menu` in queries and view variables. [[1]](diffhunk://#diff-fcf16543627b2b89223149a19e46321e3b0483f11a5557fb1880690bdabcec40R80-R81) [[2]](diffhunk://#diff-fcf16543627b2b89223149a19e46321e3b0483f11a5557fb1880690bdabcec40R96-R97)
- Updated the frontend site component to retrieve and expose `footerMenuPages` to the views, using new query methods for selected footer menu pages. [[1]](diffhunk://#diff-e60073bcb4286ae956db4295775de4c1a11a01925160086c4316126a79a13679L88-R88) [[2]](diffhunk://#diff-e60073bcb4286ae956db4295775de4c1a11a01925160086c4316126a79a13679R122-R140)

**Frontend Rendering:**
- Rendered the footer menu pages in the public site footer, styled as a navigational section, and improved the layout and accessibility of standard footer links.